### PR TITLE
fix log about race between navigation and request

### DIFF
--- a/lib/mocker.js
+++ b/lib/mocker.js
@@ -112,8 +112,6 @@ class Mocker {
         this.cachedReqs.clear()
       }
       if (this.reqSet.size !== 0) {
-        this.reqSet.clear()
-        this._resolveReqs()
         if (!this.params.ci) {
           console.error(`Some connections was not completed, but navigation happened.`)
           console.error(`That is bad, mkay? Because you have a race: server response and navigation`)
@@ -121,6 +119,8 @@ class Mocker {
           console.error(`Alive connections:\n${fy([...this.reqSet])}`)
           throw new Error(`Some connections was not completed, but navigation happened.`)
         }
+        this.reqSet.clear()
+        this._resolveReqs()
       }
     }
     // Clear on any page load, or sometimes you loose some responses on unload, and `connections` will never resolves


### PR DESCRIPTION
В логе используется `[...this.reqSet]` который предварительно чистится. В пр очистка перенесена после лога.